### PR TITLE
[bugfix] Fix typo in "XCTestManifests.swift".

### DIFF
--- a/Tests/BonaFideCharacterSetTests/XCTestManifests.swift
+++ b/Tests/BonaFideCharacterSetTests/XCTestManifests.swift
@@ -5,7 +5,7 @@ public func allTests() -> [XCTestCaseEntry] {
   return [
     testCase(BonaFideCharacterSetTests.allTests),
     testCase(NormalizedCharacterTests.allTests),
-    testCase(UnicoeScalarSetTests.allTests),
+    testCase(UnicodeScalarSetTests.allTests),
   ]
 }
 #endif


### PR DESCRIPTION
Replace `UnicoeScalarSetTests` with `UnicodeScalarSetTests`.