### PR TITLE
Enable to split strings by sets.

### DIFF
--- a/Sources/BonaFideCharacterSet/BonaFideCharacterSet.swift
+++ b/Sources/BonaFideCharacterSet/BonaFideCharacterSet.swift
@@ -8,6 +8,9 @@
 import Ranges
 import Predicate
 
+/// A set of `CharacterExpression`s.
+public typealias CharacterExpressionSet<C> = TotallyOrderedSet<C> where C:CharacterExpression
+
 /// # BonaFideCharacterSet
 ///
 /// A set of characters.
@@ -17,17 +20,17 @@ import Predicate
 ///
 /// Unlike `Foundation.CharacterSet`, this may be really a set of `Character`s.
 ///
-public typealias BonaFideCharacterSet = TotallyOrderedSet<Character>
+public typealias BonaFideCharacterSet = CharacterExpressionSet<Character>
 
 /// # DecomposedCharacterSet
 ///
 /// A set of `DecomposedCharacter`s.
-public typealias DecomposedCharacterSet = TotallyOrderedSet<DecomposedCharacter>
+public typealias DecomposedCharacterSet = CharacterExpressionSet<DecomposedCharacter>
 
 /// # PrecomposedCharacterSet
 ///
 /// A set of `PrecomposedCharacter`s.
-public typealias PrecomposedCharacterSet = TotallyOrderedSet<PrecomposedCharacter>
+public typealias PrecomposedCharacterSet = CharacterExpressionSet<PrecomposedCharacter>
 
 extension TotallyOrderedSet where Element: CharacterExpression {
   /// Initializes with characters contained in `string`.

--- a/Sources/BonaFideCharacterSet/StringProtocol+CharacterExpressionSet.swift
+++ b/Sources/BonaFideCharacterSet/StringProtocol+CharacterExpressionSet.swift
@@ -1,0 +1,28 @@
+/* *************************************************************************************************
+ StringProtocol+CharacterExpressionSet.swift
+   © 2018 YOCKOW.
+     Licensed under MIT License.
+     See "LICENSE.txt" for more information.
+ ************************************************************************************************ */
+
+extension StringProtocol {
+  /// Returns the longest possible subsequences of the collection, in order,
+  /// around elements equal to the given element.
+  public func split<C>(separator:CharacterExpressionSet<C>,
+                       maxSplits:Int = Int.max,
+                       omittingEmptySubsequences:Bool = true) -> [SubSequence]
+    where C:CharacterExpression
+  {
+    return self.split(maxSplits:maxSplits,
+                      omittingEmptySubsequences:omittingEmptySubsequences,
+                      whereSeparator:{ separator.contains(C($0)) })
+  }
+  
+  /// Returns an array containing substrings from the string
+  /// that have been divided by characters in the given set.
+  public func components<C>(separatedBy separator:CharacterExpressionSet<C>) -> [String]
+    where C: CharacterExpression
+  {
+    return self.split(separator:separator, omittingEmptySubsequences:false).map{ String($0) }
+  }
+}

--- a/Tests/BonaFideCharacterSetTests/StringProtocol+CharacterExpressionSetTests.swift
+++ b/Tests/BonaFideCharacterSetTests/StringProtocol+CharacterExpressionSetTests.swift
@@ -1,0 +1,27 @@
+/* *************************************************************************************************
+ StringProtocol+CharacterExpressionSetTests.swift
+   © 2018 YOCKOW.
+     Licensed under MIT License.
+     See "LICENSE.txt" for more information.
+ ************************************************************************************************ */
+ 
+import XCTest
+@testable import BonaFideCharacterSet
+
+import Ranges
+
+final class StringProtocol_CharacterExpressionSetTests: XCTestCase {
+  func testSplit() {
+    let string = "AA01BB23CC45DD67"
+    XCTAssertEqual(
+      string.components(separatedBy:CharacterSet(charactersIn:"01234567890")),
+      string.components(separatedBy:PrecomposedCharacterSet(charactersIn:"0"..."9"))
+    )
+  }
+  
+  static var allTests = [
+    ("testSplit", testSplit),
+  ]
+}
+
+

--- a/Tests/BonaFideCharacterSetTests/XCTestManifests.swift
+++ b/Tests/BonaFideCharacterSetTests/XCTestManifests.swift
@@ -5,6 +5,7 @@ public func allTests() -> [XCTestCaseEntry] {
   return [
     testCase(BonaFideCharacterSetTests.allTests),
     testCase(NormalizedCharacterTests.allTests),
+    testCase(StringProtocol_CharacterExpressionSetTests.allTests),
     testCase(UnicodeScalarSetTests.allTests),
   ]
 }


### PR DESCRIPTION
Extend `StringProtocol` to implement `func split<C>(separator:CharacterExpressionSet<C>, maxSplits:Int, omittingEmptySubsequences:Bool) -> [SubSequence]` and `func components<C>(separatedBy separator:CharacterExpressionSet<C>) -> [String]`.